### PR TITLE
Fix `SettingWithCopyWarning` exception

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -94,7 +94,7 @@ try:
     P_t = port[colsprice].set_index('ticker').fillna('0')
     P_t['bestTargetPrice'] = P_t['bestTargetPrice'].astype(float)
 
-    p_e = P_t[P_t['bestTargetPrice'] != 0.0]
+    p_e = P_t[P_t['bestTargetPrice'] != 0.0].copy()
     p_e.loc[:, 'pE'] = p_e['bestTargetPrice'] / p_e['pxLast'] - 1
     p_e.sort_values(by='pE', ascending=False)
     logging.info("Growth potential based on Analyst Recommendations calculated")

--- a/parser.py
+++ b/parser.py
@@ -95,7 +95,7 @@ try:
     P_t['bestTargetPrice'] = P_t['bestTargetPrice'].astype(float)
 
     p_e = P_t[P_t['bestTargetPrice'] != 0.0]
-    p_e['pE'] = p_e['bestTargetPrice'] / p_e['pxLast'] -1
+    p_e.loc[:, 'pE'] = p_e['bestTargetPrice'] / p_e['pxLast'] - 1
     p_e.sort_values(by='pE', ascending=False)
     logging.info("Growth potential based on Analyst Recommendations calculated")
     logging.info(f"Number of records processed for growth potential: {len(p_e)}")


### PR DESCRIPTION
This Pull Request is addressing:

1. **Potential bug: Setting with copy warning**: The change from `p_e['pE']` to `p_e.loc[:, 'pE']` is likely aimed at avoiding a "SettingWithCopyWarning" in pandas, which is good. However, to ensure that `p_e` is still a valid DataFrame, use `.copy()` when creating `p_e` to avoid any unintended side effects.
    - **Recommendation**: Modify the DataFrame assignment to include `.copy()` to avoid potential side effects and ensure `p_e` is a proper independent DataFrame.
    - **Example**:
      ```python
      p_e = P_t[P_t['bestTargetPrice'] != 0.0].copy()
      ```
    - **Reference**: `parser.py:98`
    ```diff parser.py:98
    @@ -95,7 +95,7 @@
    [95,95]     P_t['bestTargetPrice'] = P_t['bestTargetPrice'].astype(float)
    [96,96] 
    [97,97]     p_e = P_t[P_t['bestTargetPrice'] != 0.0]
    [98,97]-    p_e['pE'] = p_e['bestTargetPrice'] / p_e['pxLast'] -1
    [98,98]+    p_e.loc[:, 'pE'] = p_e['bestTargetPrice'] / p_e['pxLast'] - 1
    [99,99]     p_e.sort_values(by='pE', ascending=False)
    [100,100]     logging.info("Growth potential based on Analyst Recommendations calculated")
    [101,101]     logging.info(f"Number of records processed for growth potential: {len(p_e)}")
    ```
    
    

2. **Insufficient handling of empty data**: The code does not handle the situation where `P_t['bestTargetPrice']` or `P_t['pxLast']` could be empty or contain zeros, leading to potential division by zero errors.
    - **Recommendation**: Add a check to handle cases where `P_t['pxLast']` is zero to avoid division by zero errors.
    - **Example**:
      ```python
      p_e = P_t[(P_t['bestTargetPrice'] != 0.0) & (P_t['pxLast'] != 0.0)].copy()
      p_e.loc[:, 'pE'] = p_e['bestTargetPrice'] / p_e['pxLast'] - 1
      ```
    - **Reference**: `parser.py:98`
    ```diff parser.py:98
    @@ -95,7 +95,7 @@
    [95,95]     P_t['bestTargetPrice'] = P_t['bestTargetPrice'].astype(float)
    [96,96] 
    [97,97]     p_e = P_t[P_t['bestTargetPrice'] != 0.0]
    [98,97]-    p_e['pE'] = p_e['bestTargetPrice'] / p_e['pxLast'] -1
    [98,98]+    p_e.loc[:, 'pE'] = p_e['bestTargetPrice'] / p_e['pxLast'] - 1
    [99,99]     p_e.sort_values(by='pE', ascending=False)
    [100,100]     logging.info("Growth potential based on Analyst Recommendations calculated")
    [101,101]     logging.info(f"Number of records processed for growth potential: {len(p_e)}")
    ```
    
    

3. **Error messages that are vague, inconsistent, or uninformative**: The logging messages are informative but could include more details for better traceability, such as the specific column names being used for processing.
    - **Recommendation**: Enhance logging messages to include more specific details about the columns being processed.
    - **Example**:
      ```python
      logging.info("Growth potential based on Analyst Recommendations calculated using columns 'bestTargetPrice' and 'pxLast'")
      ```
    - **Reference**: `parser.py:100`
    ```diff parser.py:100
    @@ -95,7 +95,7 @@
    [95,95]     P_t['bestTargetPrice'] = P_t['bestTargetPrice'].astype(float)
    [96,96] 
    [97,97]     p_e = P_t[P_t['bestTargetPrice'] != 0.0]
    [98,97]-    p_e['pE'] = p_e['bestTargetPrice'] / p_e['pxLast'] -1
    [98,98]+    p_e.loc[:, 'pE'] = p_e['bestTargetPrice'] / p_e['pxLast'] - 1
    [99,99]     p_e.sort_values(by='pE', ascending=False)
    [100,100]     logging.info("Growth potential based on Analyst Recommendations calculated")
    [101,101]     logging.info(f"Number of records processed for growth potential: {len(p_e)}")
    ```
    
    

These recommendations aim to improve code robustness by ensuring proper handling of DataFrame copies and edge cases, and enhancing the clarity of logging messages for better traceability.