### PR TITLE
Remove replaces-base option from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ registries:
   github:
     type: git
     url: https://github.com/
-    replaces-base: true
     username: x-access-token
     password: ${{ secrets.DEPENDABOT }}
 updates:


### PR DESCRIPTION
Removed 'replaces-base' option from GitHub registry configuration.